### PR TITLE
Use TemporaryDirectory in test_detector_no_error

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -13,6 +13,7 @@ Tests:
 """
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -31,17 +32,17 @@ def get_config_for_env(env: str) -> Path:
 @pytest.mark.parametrize("Env", ENVS)
 def test_detector_no_error(Env) -> None:
     config_path = get_config_for_env(Env.__name__)
-    save_dir = "/tmp/models"
-    model = train_center_track(
-        config_path,
-        save_dir,
-        max_epochs=1,
-        epoch_size=100,
-        img_scale=4,
-        grayscale=True,
-        force_offline=True,
-        prog_bar=False,
-    )
+    with TemporaryDirectory(prefix="models") as save_dir:
+        model = train_center_track(
+            config_path,
+            save_dir,
+            max_epochs=1,
+            epoch_size=100,
+            img_scale=4,
+            grayscale=True,
+            force_offline=True,
+            prog_bar=False,
+        )
     # TODO: load detector from checkpoint, ensure it matches the current model
 
 


### PR DESCRIPTION
## Description

Use `tempfile.TemporaryDirectory` instead of hard-coding the temporary directory for saving the trained model during the `test_detector_no_error` test, for platform compatibility.

## Details

This is a small suggestion in the hopes of making the test a bit more robust regarding using a temporary directory (for platforms where `/tmp/` is not available and similar slightly esoteric cases, using the stdlib facilities instead).

The handling of temporary directories for this particular test is slightly changed with this PR (a new directory would be created for each environment _and_ automatically deleted, instead of always reusing the same directory) - I was unsure if it was critical to preserve the previous behaviour. If so, I'd be happy to use alternatives such as `mkdtemp` that allow for finer control.